### PR TITLE
fixed issue related to headphone connection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.Manifest.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
 
     <application
         android:name=".App"


### PR DESCRIPTION
Fixed issue that when headphone devices (including wired and Bluetooth) disconnected the current audio continues to play. After the fix, after headphones disconnection, audio play will be stopped automatically. Also, after headphones re-connection, audio play can continue to play.